### PR TITLE
Fixes #17417: Convert to date *after* finding max and min, not before

### DIFF
--- a/public_html/lists/admin/actions/export.php
+++ b/public_html/lists/admin/actions/export.php
@@ -38,9 +38,9 @@ $exportfile = fopen($exportfileName,'w');
 if ($_SESSION['export']['column'] == 'nodate') {
   ## fetch dates as min and max from user table
   if ($list) {
-    $dates = Sql_Fetch_Row_Query(sprintf('select min(date(user.modified)),max(date(user.modified)) from %s where listid = %d %s',$querytables,$list,$subselect));
+    $dates = Sql_Fetch_Row_Query(sprintf('select date(min(user.modified)),date(max(user.modified)) from %s where listid = %d %s',$querytables,$list,$subselect));
   } else {
-    $dates = Sql_Fetch_Row_Query(sprintf('select min(date(user.modified)),max(date(user.modified)) from %s ',$querytables));
+    $dates = Sql_Fetch_Row_Query(sprintf('select date(min(user.modified)),date(max(user.modified)) from %s ',$querytables));
   }
 
   $fromdate = $dates[0];


### PR DESCRIPTION
I wasn't able to create a Mantis account, but I have confirmed the *significant* performance improvements on my server via the MySQL.

Adding an index to the modified row makes it even faster, but isn't really necessary.

Signed-off-by: Dan Rumney <dancrumb@gmail.com>