### PR TITLE
Fixes #17417: Some changes needed around table joins to make them smaller

### DIFF
--- a/public_html/lists/admin/actions/export.php
+++ b/public_html/lists/admin/actions/export.php
@@ -7,27 +7,30 @@ $list = $_SESSION['export']['list'];
 
 switch ($access) {
   case 'owner':
-    $querytables = $GLOBALS['tables']['list'].' list ,'.$GLOBALS['tables']['user'].' user ,'.$GLOBALS['tables']['listuser'].' listuser ';
-    $subselect = ' and listuser.listid = list.id and listuser.userid = user.id and list.owner = ' . $_SESSION['logindetails']['id'];
-    $listselect_where = ' where owner = ' . $_SESSION['logindetails']['id'];
-    $listselect_and = ' and owner = ' . $_SESSION['logindetails']['id'];
-    break;
-  case 'all':
     if ($list) {
-      $querytables = $GLOBALS['tables']['user'].' user'.', '.$GLOBALS['tables']['listuser'].' listuser';
-      $subselect = ' and listuser.userid = user.id ';
+      $querytables = $GLOBALS['tables']['list'].' list INNER JOIN '. $GLOBALS['tables']['listuser'].' listuser ON listuser.listid = list.id'.
+                                                     ' INNER JOIN '.$GLOBALS['tables']['user'].' user ON listuser.userid = user.id';
+      $subselect = ' and list.owner = ' . $_SESSION['logindetails']['id'];
+      $listselect_and = ' and owner = ' . $_SESSION['logindetails']['id'];
     } else {
       $querytables = $GLOBALS['tables']['user'].' user';
       $subselect = '';
     }
-    $listselect_where = '';
+    break;
+  case 'all':
+    if ($list) {
+      $querytables = $GLOBALS['tables']['user'].' user'.' INNER JOIN '.$GLOBALS['tables']['listuser'].' listuser ON user.id = listuser.userid';
+      $subselect = '';
+    } else {
+      $querytables = $GLOBALS['tables']['user'].' user';
+      $subselect = '';
+    }
     $listselect_and = '';
     break;
   case 'none':
   default:
     $querytables = $GLOBALS['tables']['user'].' user';
     $subselect = ' and user.id = 0';
-    $listselect_where = ' where owner = 0';
     $listselect_and = ' and owner = 0';
     break;
 }

--- a/public_html/lists/admin/export.php
+++ b/public_html/lists/admin/export.php
@@ -24,28 +24,26 @@ if (isset($_REQUEST['list'])) {
 $access = accessLevel('export');
 switch ($access) {
   case 'owner':
-    $querytables = $GLOBALS['tables']['list'].' list ,'.$GLOBALS['tables']['user'].' user ,'.$GLOBALS['tables']['listuser'].' listuser ';
-    $subselect = ' and listuser.listid = list.id and listuser.userid = user.id and list.owner = ' . $_SESSION['logindetails']['id'];
+    $querytables = $GLOBALS['tables']['list'].' list INNER JOIN '. $GLOBALS['tables']['listuser'].' listuser ON listuser.listid = list.id'.
+                                                   ' INNER JOIN '.$GLOBALS['tables']['user'].' user ON listuser.userid = user.id';
+    $subselect = ' and list.owner = ' . $_SESSION['logindetails']['id'];
     $listselect_where = ' where owner = ' . $_SESSION['logindetails']['id'];
-    $listselect_and = ' and owner = ' . $_SESSION['logindetails']['id'];
     break;
   case 'all':
     if ($list) {
-      $querytables = $GLOBALS['tables']['user'].' user'.', '.$GLOBALS['tables']['listuser'].' listuser';
-      $subselect = ' and listuser.userid = user.id ';
+      $querytables = $GLOBALS['tables']['user'].' user'.', '.$GLOBALS['tables']['listuser'].' listuser ON user.id = listuser.userid';
+      $subselect = '';
     } else {
       $querytables = $GLOBALS['tables']['user'].' user';
       $subselect = '';
     }
     $listselect_where = '';
-    $listselect_and = '';
     break;
   case 'none':
   default:
     $querytables = $GLOBALS['tables']['user'].' user';
     $subselect = ' and user.id = 0';
     $listselect_where = ' where owner = 0';
-    $listselect_and = ' and owner = 0';
     break;
 }
 


### PR DESCRIPTION
It turns out that original fix wasn't quite enough.

The table joins when `$access == 'all'` and `$list` is not zero are full Cartesian joins which hoses any large installation.

As I was fixing that, I found a few other things to tidy up... I know... "Tidy up" is a little presumptuous, but there were a few unused variables that I removed and, in my experience, `JOIN`ing with `ON` clauses is a little safer than with `WHERE` clauses (in terms of maintenance), especially if you're separating you table definition strings and your `WHERE` strings.

Signed-off-by: Dan Rumney <dancrumb@gmail.com>