### PR TITLE
Change HTTP_HOST by SERVER_NAME in referer check

### DIFF
--- a/public_html/lists/admin/index.php
+++ b/public_html/lists/admin/index.php
@@ -166,7 +166,7 @@ if ($GLOBALS["commandline"]) {
   if (CHECK_REFERRER && isset($_SERVER['HTTP_REFERER'])) {
     ## do a crude check on referrer. Won't solve everything, as it can be faked, but shouldn't hurt
     $ref = parse_url($_SERVER['HTTP_REFERER']);
-    if ($ref['host'] != $_SERVER['SERVER_NAME'] && !in_array($ref['host'],$allowed_referrers)) {
+    if ($ref['host'] != $_SERVER['SERVER_NAME'] && $ref['host'] != $_SERVER['HTTP_HOST'] && !in_array($ref['host'],$allowed_referrers)) {
       print 'Access denied';exit;
     }
   }

--- a/public_html/lists/admin/index.php
+++ b/public_html/lists/admin/index.php
@@ -166,7 +166,7 @@ if ($GLOBALS["commandline"]) {
   if (CHECK_REFERRER && isset($_SERVER['HTTP_REFERER'])) {
     ## do a crude check on referrer. Won't solve everything, as it can be faked, but shouldn't hurt
     $ref = parse_url($_SERVER['HTTP_REFERER']);
-    if ($ref['host'] != $_SERVER['HTTP_HOST'] && !in_array($ref['host'],$allowed_referrers)) {
+    if ($ref['host'] != $_SERVER['SERVER_NAME'] && !in_array($ref['host'],$allowed_referrers)) {
       print 'Access denied';exit;
     }
   }


### PR DESCRIPTION
If virtual host of phplist installation isn't in default port 80, the referer check isn't working and send a unclear 'Access denied'. 
Changing HTTP_HOST by SERVER_NAME avoids this problem.