### PR TITLE
Remove port from HTTP_HOST header in referer check

### DIFF
--- a/public_html/lists/admin/index.php
+++ b/public_html/lists/admin/index.php
@@ -166,7 +166,8 @@ if ($GLOBALS["commandline"]) {
   if (CHECK_REFERRER && isset($_SERVER['HTTP_REFERER'])) {
     ## do a crude check on referrer. Won't solve everything, as it can be faked, but shouldn't hurt
     $ref = parse_url($_SERVER['HTTP_REFERER']);
-    if ($ref['host'] != $_SERVER['HTTP_HOST'] && !in_array($ref['host'],$allowed_referrers)) {
+    list($http_host, $http_port) = explode(':', $_SERVER['HTTP_HOST']);
+    if ($ref['host'] != $http_host && !in_array($ref['host'],$allowed_referrers)) {
       print 'Access denied';exit;
     }
   }

--- a/public_html/lists/admin/index.php
+++ b/public_html/lists/admin/index.php
@@ -166,8 +166,8 @@ if ($GLOBALS["commandline"]) {
   if (CHECK_REFERRER && isset($_SERVER['HTTP_REFERER'])) {
     ## do a crude check on referrer. Won't solve everything, as it can be faked, but shouldn't hurt
     $ref = parse_url($_SERVER['HTTP_REFERER']);
-    list($http_host, $http_port) = explode(':', $_SERVER['HTTP_HOST']);
-    if ($ref['host'] != $http_host && !in_array($ref['host'],$allowed_referrers)) {
+    $parts = explode(':', $_SERVER['HTTP_HOST']);
+    if ($ref['host'] != $parts[0] && !in_array($ref['host'],$allowed_referrers)) {
       print 'Access denied';exit;
     }
   }


### PR DESCRIPTION
If virtual host of phplist installation isn't in default port 80, the HTTP_HOST var contains the port too, so referer check fails. 
Trim port from HTTP_HOST solves the issue.