### PR TITLE
Enable support for autoconfirming users

### DIFF
--- a/public_html/lists/admin/defaultconfig.php
+++ b/public_html/lists/admin/defaultconfig.php
@@ -646,7 +646,14 @@ Thank you.
   'category'=> 'system',
   'hidden' => true,
   ),
-
+'autoconfirm' => array(
+  'value' => "0",
+  'description' => "Should users be autoconfirmed",
+  'type' => "boolean",
+  'allowempty' => true,
+  'category'=> 'subscription',
+  'hidden' => false,
+  ),
 );
 
 ########## certainly do not edit after this #########

--- a/public_html/lists/admin/subscribelib2.php
+++ b/public_html/lists/admin/subscribelib2.php
@@ -312,8 +312,13 @@ if (isset($_POST["subscribe"]) && is_email($_POST["email"]) && $listsok && $allt
 
    print '<title>'.$GLOBALS["strSubscribeTitle"].'</title>';
    print $subscribepagedata["header"];
-
-   if (isset($_SESSION["adminloggedin"]) && $_SESSION["adminloggedin"] && !(isset($_GET['p']) && $_GET['p'] == 'asubscribe')) {
+   
+    if ($_POST["makeconfirmed"] && !$blacklisted && getConfig("autoconfirm")) {
+         $sendrequest = 0;
+         Sql_Query(sprintf('update %s set confirmed = 1 where email = "%s"',$GLOBALS["tables"]["user"],$email));
+         addUserHistory($email,$history_subject." autoconfirmed",$history_entry);
+   }
+   else if (isset($_SESSION["adminloggedin"]) && $_SESSION["adminloggedin"] && !(isset($_GET['p']) && $_GET['p'] == 'asubscribe')) {
       print '<p class="information"><b>You are logged in as '.$_SESSION["logindetails"]["adminname"].'</b></p>';
       print '<p><a href="'.$adminpages.'" class="button">Back to the main admin page</a></p>';
 
@@ -381,9 +386,7 @@ if (isset($_POST["subscribe"]) && is_email($_POST["email"]) && $listsok && $allt
     }
   } else {
       print $thankyoupage;
-      if ($_SESSION["adminloggedin"]) {
-         print '<p class="information">User has been added and confirmed</p>';
-      }
+      print '<p class="information">User has been added and confirmed</p>';
    }
 
    print '<p class="information">'.$PoweredBy.'</p>';

--- a/public_html/lists/admin/subscribelib2.php
+++ b/public_html/lists/admin/subscribelib2.php
@@ -387,6 +387,11 @@ if (isset($_POST["subscribe"]) && is_email($_POST["email"]) && $listsok && $allt
   } else {
       print $thankyoupage;
       print '<p class="information">User has been added and confirmed</p>';
+       if (!TEST) {
+        $confirmMsg = getConfig("confirmationmessage");
+        $confirmationmessage = str_ireplace('[LISTS]', $lists,  $confirmMsg);
+        sendMail($"email", getConfig("confirmationsubject"), $confirmationmessage,system_messageheaders(),$envelope);
+       }
    }
 
    print '<p class="information">'.$PoweredBy.'</p>';

--- a/public_html/lists/index.php
+++ b/public_html/lists/index.php
@@ -584,6 +584,9 @@ function checkGroup(name,value)
     $html .= '<p><b>'.s('Please choose').'</b>: <br/><input type=radio name="makeconfirmed" value="1"> '.s('Make this subscriber confirmed immediately').'
       <br/><input type=radio name="makeconfirmed" value="0" checked> '.s('Send this subscriber a request for confirmation email').' </p></div>';
   }
+  else if(getConfig("autoconfirm")){
+    $html .= '<input type="hidden" name="makeconfirmed" value="1">';
+  }
   $html .= '<table border=0>';
   $html .= ListAttributes($attributes,$attributedata,$GLOBALS['pagedata']["htmlchoice"],0,$GLOBALS['pagedata']['emaildoubleentry']);
   $html .= '</table>';


### PR DESCRIPTION
Enables support for autoconfirming users.

This is an especially useful feature for when the user is subscribing to receive text messages on a cell phone without Internet access, and so are unable to click on the confirm link.